### PR TITLE
add flexbox layout for superheader

### DIFF
--- a/src/components/SuperHeader/SuperHeader.js
+++ b/src/components/SuperHeader/SuperHeader.js
@@ -26,10 +26,15 @@ const Wrapper = styled.div`
   font-size: 0.875rem;
   color: ${COLORS.gray[300]};
   background-color: ${COLORS.gray[900]};
+  padding: 12px 32px;
+  display: flex;
+  gap: 24px;
+  
 `;
 
 const MarketingMessage = styled.span`
   color: ${COLORS.white};
+  margin-right: auto;
 `;
 
 const HelpLink = styled.a`


### PR DESCRIPTION
Submission for [Exercise 1: Superheader](https://github.com/VrsajkovIvan33/sole-and-ankle?tab=readme-ov-file#exercise-1-superheader).

Make the superheader a flexbox, and add padding, gap and `margin-right: auto;` to get the desired layout.