### PR TITLE
add flex layout to header

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -21,17 +21,27 @@ const Header = () => {
           <NavLink href="/kids">Kids</NavLink>
           <NavLink href="/collections">Collections</NavLink>
         </Nav>
+        <FlexFiller />
       </MainHeader>
     </header>
   );
 };
 
+const FlexFiller = styled.div`
+  flex: 1;
+`;
+
 const MainHeader = styled.div`
   padding: 0 32px;
   border-bottom: 1px solid ${COLORS.gray[300]};
+  display: flex;
+  align-items: baseline;
 `;
 
-const Nav = styled.nav``;
+const Nav = styled.nav`
+  display: flex;
+  gap: 48px;
+`;
 
 const NavLink = styled.a`
   font-size: 1.125rem;
@@ -44,5 +54,9 @@ const NavLink = styled.a`
     color: ${COLORS.secondary};
   }
 `;
+
+// const FlexLogo = styled(Logo)`
+//   flex: 1;
+// `;
 
 export default Header;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -55,8 +55,4 @@ const NavLink = styled.a`
   }
 `;
 
-// const FlexLogo = styled(Logo)`
-//   flex: 1;
-// `;
-
 export default Header;

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/macro';
+import Header from '../Header/Header';
 
 import { WEIGHTS } from '../../constants';
 
@@ -14,6 +15,11 @@ const Logo = (props) => {
 const Link = styled.a`
   text-decoration: none;
   color: inherit;
+  
+  ${Header} & {
+    flex: 1;
+    margin-right:
+  }
 `;
 
 const Wrapper = styled.h1`


### PR DESCRIPTION
Submission for [Exercise 2: Header](https://github.com/VrsajkovIvan33/sole-and-ankle?tab=readme-ov-file#exercise-2-header).

We want an equal spacing on either side of the menu in the header:
![image](https://github.com/VrsajkovIvan33/sole-and-ankle/assets/20580410/578444ba-6af5-4617-bd5b-1ce213edfd8b)

Ideally, we want this _not_ hardcoded + the spacing on the left and right needs to shrink equally as the viewport shrinks. To achieve this, we set `flex: 1;` on the `Logo` component and add another dummy component with `flex: 1;` on the other side. These two components eat up all the available space, resulting in the desired layout.

We use inversion of control nesting to add the styling on the `Logo` component as composition won't work without its refactoring, as all the passed props are forwarded into the `Wrapper` child element, not the outer `Link` one.
