### PR TITLE
set flex layout for shell

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -32,7 +32,10 @@ const Select = ({ label, value, children, ...delegated }) => {
   );
 };
 
-const Wrapper = styled.label``;
+const Wrapper = styled.label`
+  display: flex;
+  align-items: center;
+`;
 
 const VisibleLabel = styled.span`
   color: ${COLORS.gray[700]};

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -45,19 +45,26 @@ const ShoeIndex = ({ sortId, setSortId }) => {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: row-reverse;
+  gap: 32px;
 `;
 
-const LeftColumn = styled.div``;
+const LeftColumn = styled.div`
+  flex-basis: 248px;
+  padding-top: 8px;
+`;
 
 const MainColumn = styled.div`
   flex-grow: 1;
 `;
 
-const Header = styled.header``;
+const Header = styled.header`
+  display: flex;
+`;
 
 const Title = styled.h2`
   font-size: 1.5rem;
   font-weight: ${WEIGHTS.medium};
+  margin-right: auto;
 `;
 
 export default ShoeIndex;

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -42,11 +42,16 @@ const ShoeIndex = ({ sortId, setSortId }) => {
   );
 };
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+`;
 
 const LeftColumn = styled.div``;
 
-const MainColumn = styled.div``;
+const MainColumn = styled.div`
+  flex-grow: 1;
+`;
 
 const Header = styled.header``;
 

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -25,7 +25,7 @@ const ShoeIndex = ({ sortId, setSortId }) => {
           </Select>
         </Header>
         <Spacer size={34} />
-        <ShoeGrid />
+        {/* <ShoeGrid /> */}
       </MainColumn>
       <LeftColumn>
         <Breadcrumbs>


### PR DESCRIPTION
Submission for [Exercise 3: Shell](https://github.com/VrsajkovIvan33/sole-and-ankle?tab=readme-ov-file#exercise-3-shell).

The order of the two columns is reversed but the tabbing remains unaffected.

The breadcrumbs and the "Running" text are not alligned since they don't belong to the same flexbox container. As a temporary solution, I increased the padding above breadcrumbs until we see what the recommended solution is.