### PR TITLE
set flex layout in shoe grid

### DIFF
--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -53,15 +53,20 @@ const ShoeCard = ({
 const Link = styled.a`
   text-decoration: none;
   color: inherit;
+  flex: 1;
 `;
 
-const Wrapper = styled.article``;
+const Wrapper = styled.article`
+  min-width: 340px;
+`;
 
 const ImageWrapper = styled.div`
   position: relative;
 `;
 
-const Image = styled.img``;
+const Image = styled.img`
+  width: 100%;
+`;
 
 const Row = styled.div`
   font-size: 1rem;

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -53,11 +53,10 @@ const ShoeCard = ({
 const Link = styled.a`
   text-decoration: none;
   color: inherit;
-  flex: 1;
+  flex: 1 0 340px;
 `;
 
 const Wrapper = styled.article`
-  min-width: 340px;
 `;
 
 const ImageWrapper = styled.div`

--- a/src/components/ShoeGrid/ShoeGrid.js
+++ b/src/components/ShoeGrid/ShoeGrid.js
@@ -14,6 +14,10 @@ const ShoeGrid = () => {
   );
 };
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+`;
 
 export default ShoeGrid;

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -25,7 +25,7 @@ const ShoeIndex = ({ sortId, setSortId }) => {
           </Select>
         </Header>
         <Spacer size={34} />
-        {/* <ShoeGrid /> */}
+        <ShoeGrid />
       </MainColumn>
       <LeftColumn>
         <Breadcrumbs>


### PR DESCRIPTION
Submission for [Exercise 4A: Shoe Grid layout](https://github.com/VrsajkovIvan33/sole-and-ankle?tab=readme-ov-file#4a-grid-layout).

The grid-like layout is achieved with:
- `flex: 1 0 340px;` on `ShoeCard`,
- `width: 100%;` on the image in `ShoeCard`, and
- `flex-wrap: wrap;` on `ShoeGrid`.

`flex: 1 0 340px;` defines the size of the `ShoeCard` elements, allowing us to use `width: 100%;` on the image. Since we prevent any shrinking beyond `340px`, we use `flex-wrap: wrap;` to deal with the overflow.
