### PR TITLE
add "just released" and "sale" styles

### DIFF
--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -31,31 +31,54 @@ const ShoeCard = ({
       ? 'new-release'
       : 'default'
 
+  const justReleasedFlagStyle = {
+    "new-release": { "--display": "block" },
+    "default": { "--display": "none" },
+    "on-sale": { "--display": "none" },
+  };
+  const saleFlagStyle = {
+    "on-sale": { "--display": "block" },
+    "default": { "--display": "none" },
+    "new-release": { "--display": "none" },
+  };
+  const priceStyle = {
+    "on-sale": { "--text-color": COLORS.gray[700], "--text-decoration": "line-through" },
+    "default": { "--text-color": COLORS.gray[900], "--text-decoration": "inherit" },
+    "new-release": { "--text-color": COLORS.gray[900], "--text-decoration": "inherit" }
+  };
+  const salePriceStyle = {
+    "on-sale": { "--display": "inline" },
+    "default": { "--display": "none" },
+    "new-release": { "--display": "none" }
+  }
+
   return (
     <Link href={`/shoe/${slug}`}>
       <Wrapper>
         <ImageWrapper>
           <Image alt="" src={imageSrc} />
-          <JustReleasedFlag style={{ "--display": variant === "new-release" ? "block" : "none" }}>
+          <JustReleasedFlag style={justReleasedFlagStyle[variant]}>
             Just released!
           </JustReleasedFlag>
-          <SaleFlag style={{ "--display": variant === "on-sale" ? "block" : "none" }}>
+          <SaleFlag style={saleFlagStyle[variant]}>
             Sale
           </SaleFlag>
         </ImageWrapper>
         <Spacer size={12} />
         <Row>
           <Name>{name}</Name>
-          <Price style={{ "--text-decoration": variant === "on-sale" ? "line-through" : "inherit" }}>
+          <Price style={priceStyle[variant]}>
             {formatPrice(price)}
           </Price>
         </Row>
         <Row>
           <ColorInfo>{pluralize('Color', numOfColors)}</ColorInfo>
-          <SalePrice>{formatPrice(salePrice)}</SalePrice>
+          <SalePrice style={salePriceStyle[variant]}>
+            {formatPrice(salePrice)}
+          </SalePrice>
         </Row>
       </Wrapper>
-    </Link>
+    </Link >
   );
 };
 
@@ -88,6 +111,7 @@ const Name = styled.h3`
 `;
 
 const Price = styled.span`
+  color: var(--text-color);
   text-decoration: var(--text-decoration);
 `;
 

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -36,6 +36,13 @@ const ShoeCard = ({
       <Wrapper>
         <ImageWrapper>
           <Image alt="" src={imageSrc} />
+          <JustReleasedFlag style={{ "--display": variant === "new-release" ? "block" : "none" }}>
+            Just released!
+          </JustReleasedFlag>
+          <SaleFlag style={{ "--display": variant === "on-sale" ? "block" : "none" }}>
+            Sale
+          </SaleFlag>
+
         </ImageWrapper>
         <Spacer size={12} />
         <Row>
@@ -87,6 +94,24 @@ const ColorInfo = styled.p`
 const SalePrice = styled.span`
   font-weight: ${WEIGHTS.medium};
   color: ${COLORS.primary};
+`;
+
+const Flag = styled.div`
+  position: absolute;
+  top: 12px;
+  right: -4px;
+  border-radius: 4px;
+  padding: 8px 10px;
+  color: ${COLORS.white};
+  display: var(--display);
+`;
+
+const JustReleasedFlag = styled(Flag)`
+  background-color: ${COLORS.secondary};
+`;
+
+const SaleFlag = styled(Flag)`
+  background-color: ${COLORS.primary};
 `;
 
 export default ShoeCard;

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -42,15 +42,17 @@ const ShoeCard = ({
           <SaleFlag style={{ "--display": variant === "on-sale" ? "block" : "none" }}>
             Sale
           </SaleFlag>
-
         </ImageWrapper>
         <Spacer size={12} />
         <Row>
           <Name>{name}</Name>
-          <Price>{formatPrice(price)}</Price>
+          <Price style={{ "--text-decoration": variant === "on-sale" ? "line-through" : "inherit" }}>
+            {formatPrice(price)}
+          </Price>
         </Row>
         <Row>
           <ColorInfo>{pluralize('Color', numOfColors)}</ColorInfo>
+          <SalePrice>{formatPrice(salePrice)}</SalePrice>
         </Row>
       </Wrapper>
     </Link>
@@ -85,15 +87,19 @@ const Name = styled.h3`
   margin-right: auto;
 `;
 
-const Price = styled.span``;
+const Price = styled.span`
+  text-decoration: var(--text-decoration);
+`;
 
 const ColorInfo = styled.p`
   color: ${COLORS.gray[700]};
+  margin-right: auto;
 `;
 
 const SalePrice = styled.span`
   font-weight: ${WEIGHTS.medium};
   color: ${COLORS.primary};
+  display: var(--display);
 `;
 
 const Flag = styled.div`


### PR DESCRIPTION
Submission for [Exercise 4B: Final touches](https://github.com/VrsajkovIvan33/sole-and-ankle?tab=readme-ov-file#4b-final-touches).

- Add the "Just released!" and "Sale" flags on the sneaker image.
- Add styles on the price and sale price, when applicable.

These styles depend on the `variant` of the `ShoeCard`.